### PR TITLE
Workaround for KnpLabs/KnpMenu#137 BC break

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     },
     "require": {
         "php": ">=5.4.4",
-        "akeneo/pim-community-dev": "v1.0.3"
+        "akeneo/pim-community-dev": "v1.0.3",
+        "knplabs/knp-menu": "2.0.x-dev#ff1a6e73e79c9f75c6a130d03b07f05c89fede63"
     },
     "repositories": [
         {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Tests pass? | n/a |
| Scenarios pass? | n/a |
| Checkstyle issues? | n/a |
| Changelog updated? | n/a |
| Fixed tickets | n/a |
| Doc PR | n/a |

As KnpLabs/KnpMenu#137 introduces a BC break, every site with menu fails with an error. This is a temporary workaround, which locks the version to a commit before the pull request, which introduced the BC break. This prevents new installs from being erroneous until the break in orocrm/platform#61 gets fixed.

Users who are updating their standard edition installs via composer may still run in this issue.
