### PR TITLE
[TR] PIM-4928 : minor changes to 1.3 - 1.4 migration instructions

### DIFF
--- a/UPGRADE-1.4.md
+++ b/UPGRADE-1.4.md
@@ -9,7 +9,7 @@
 Download the latest [PIM community standard](http://www.akeneo.com/download/) and extract it:
 
 ```
- wget http://www.akeneo.com/pim-community-standard-v1.4-latest.tar.gz
+ wget http://download.akeneo.com/pim-community-standard-v1.4-latest.tar.gz
  tar -zxf pim-community-standard-v1.4-latest.tar.gz
  cd pim-community-standard-v1.4.*/
 ```
@@ -45,6 +45,7 @@ Now you're ready to update your dependencies:
 
 ```
  cd $PIM_DIR
+ rm -rf app/cache/*
  composer update
 ```
 


### PR DESCRIPTION
- Fix Download URL
- Need to clear cache before composer update because of Symfony version bump.