### PR TITLE
[TR] PIM-5055: Fix medias migration for removed product media values

### DIFF
--- a/UPGRADE-1.4.md
+++ b/UPGRADE-1.4.md
@@ -259,6 +259,13 @@ php upgrades/1.3-1.4/mongodb/migrate_medias.php
 
 If you do not use the default product tables or the default media directory, please read the scripts to know which options are available for you.
 
+If you migrated your medias from a 1.3 Mongo install to a 1.4 version prior to 1.4.6 and you get a "The identifier id is missing for a query of Akeneo\Component\FileStorage\Model\FileInfo" error in the application, it could be related to the different ways deleted medias are stored in product values between 1.3 and 1.4.
+Launch the following queries on your Mongo database to clean your product values :
+
+```
+db.pim_catalog_product.update({"values.media": {$exists: 1}}, {$pull: {"values": {"media._id": {$exists: 1}}}}, {"multi": 1})
+```
+
 ### What if you were using *Gaufrette*?
 
 Replace *Gaufrette* filesystems' by *Flysystem* ones':

--- a/upgrades/1.3-1.4/mongodb/MediaMigration.php
+++ b/upgrades/1.3-1.4/mongodb/MediaMigration.php
@@ -112,6 +112,36 @@ class MediaMigration extends AbstractMediaMigration
     }
 
     /**
+     * Clean product values that contained deleted media. These values were keeped in 1.3 but should be deleted for 1.4.
+     *
+     * Important : Should always be executed AFTER migrateMediasOnProductValue()
+     *
+     * @param string $productValueTable
+     */
+    public function removeEmptyProductValues($productValueTable)
+    {
+        $db              = $this->getMongoDatabase();
+        $valueCollection = new \MongoCollection($db, $productValueTable);
+
+        /*
+         db.pim_catalog_product.update(
+            {"values.media": {$exists: 1}},
+            {$pull: {"values": {"media._id": {$exists: 1}}}},
+            {"multi": 1}
+        )
+         */
+        $valueCollection->update(
+            ['values.media' => ['$exists' => true]],
+            [
+                '$pull' => [
+                    'values' => ['media._id' => ['$exists' => true]]
+                ]
+            ],
+            ['multiple' => true]
+        );
+    }
+
+    /**
      * @return \MongoDB
      */
     protected function getMongoDatabase()

--- a/upgrades/1.3-1.4/mongodb/migrate_medias.php
+++ b/upgrades/1.3-1.4/mongodb/migrate_medias.php
@@ -32,6 +32,7 @@ $migration->storeLocalMedias();
 
 $migration->setOriginalFilenameToMedias($valueTable);
 $migration->migrateMediasOnProductValue($valueTable);
+$migration->removeEmptyProductValues($valueTable);
 
 $migration->cleanFileInfoTable();
 $migration->close();


### PR DESCRIPTION
- Fix the Mongo medias migration script to clean product values that contained deleted medias (it was keeped in 1.3 but removed in 1.4)
- Update the upgrade.md to provide queries to help people who already migrated to clean their product values