### PR TITLE
[TR][SLA] PIM-5342: Added missing script that migrate product normalized valuesof medias for mongodb users

### DIFF
--- a/UPGRADE-1.4.md
+++ b/UPGRADE-1.4.md
@@ -255,6 +255,7 @@ php upgrades/1.3-1.4/orm/migrate_medias.php
 
 # for products that are stored with Mongo
 php upgrades/1.3-1.4/mongodb/migrate_medias.php
+php upgrades/1.3-1.4/mongodb/repair_medias_normalized_data.php
 ```
 
 > Please note that these scripts need to be modified if you do not use the regular PIM tables, collections or the default media directory. This can happen for example, when you override an entity in a custom project, or when you use the CustomEntityBundle. Please read the scripts to know which options are available for you.

--- a/upgrades/1.3-1.4/mongodb/repair_medias_normalized_data.php
+++ b/upgrades/1.3-1.4/mongodb/repair_medias_normalized_data.php
@@ -1,0 +1,31 @@
+<?php
+
+use Pim\Upgrade\MongoDB\MediaMigration;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+require_once __DIR__ . '/../../../app/bootstrap.php.cache';
+require_once __DIR__ . '/../../../app/AppKernel.php';
+require_once __DIR__ . '/../../SchemaHelper.php';
+require_once __DIR__ . '/../../UpgradeHelper.php';
+require_once __DIR__ . '/../common/AbstractMediaMigration.php';
+require_once __DIR__ . '/MediaMigration.php';
+
+// TO BE LAUNCHED AFTER HAVING UPDATED THE DEPENDENCIES OF YOUR PROJECT
+// NOT ABLE TO USE DOCTRINE ORM/MONGODB AS DEPENDENCIES HAVE BEEN UPDATED BUT NOT THE DATABASE AT THIS POINT
+// (IE: DOCTRINE MAPPINGS HAVE CHANGED BUT NOT THE DATABASE)
+
+/**********************************************
+ * USAGE
+ * repair_medias_normalized_data.php [--env environment] [--media-directory directory]
+ * with:
+ *      environment: your application environment (dev, prod...), default is dev
+ *      directory: the directory where your product medias are located, default is %kernel.root_dir%/uploads/product/
+ **********************************************/
+
+$migration = new MediaMigration(new ConsoleOutput(), new ArgvInput($argv));
+
+$valueTable = $migration->getSchemaHelper()->getTableOrCollection('product_value');
+
+$migration->migrateMediasNormalizedData($valueTable);
+$migration->close();


### PR DESCRIPTION
Fixes cases where product normalized values are not sync with the file info table:

```
db.pim_catalog_product.aggregate([
    {$match: {_id: ObjectId("55d3ef54db4c5dda148d2d82")}}, 
    {$unwind: "$values"}, 
    {$match: {"values.media": {$exists: true}}}, 
    {$project: {"values": 1, "normalizedData.image": 1}}
]).pretty();
```

```
{
	"_id" : ObjectId("55d3ef54db4c5dda148d2d82"),
	"normalizedData" : {
		"image" : {
			"id" : NumberLong(1658),
			"key" : "e/9/6/1/e96189b7afd9f923ef81fe712e24d717113a9935_55d3ef51eaaed_ruk901r600ww00_image___1439952721_zf_r600_glam.jpg",
			"originalFilename" : "zf-r600-glam.jpg"
		}
	},
	"values" : {
		"_id" : ObjectId("55d3ef54db4c5dda148d2d99"),
		"assetIds" : [ ],
		"attribute" : NumberLong(421),
		"entity" : DBRef("pim_catalog_product", ObjectId("55d3ef54db4c5dda148d2d82"), "hills_sit_test"),
		"media" : NumberLong(1658),
		"optionIds" : [ ],
		"prices" : [ ]
	}
}
```

```
mysql> select * from akeneo_file_storage_file_info where id = 1658\G;
*************************** 1. row ***************************
               id: 1658
         file_key: 3/2/8/f/328f15d3cf9a34a9e1da6fb59f640fbf8b27af8e_55d3ef51eaaed_ruk901r600ww00_image___1439952721_zf_r600_glam.jpg
original_filename: 55d3ef51eaaed-ruk901r600ww00-image---1439952721-zf-r600-glam.jpg
        mime_type: image/jpeg
             size: 145895
        extension: jpg
             hash: 92c0df558c7eb059aacce43bc783daddcd2918c5
          storage: catalogStorage
1 row in set (0.00 sec)
```

