### PR TITLE
Remove useless vcs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,6 @@
             "type": "vcs",
             "url": "https://github.com/akeneo/pim-community-dev.git",
             "branch": "master"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/akeneo/platform.git",
-            "branch": "master"
         }
     ],
     "scripts": {


### PR DESCRIPTION
Since we moved remaining oro bundles in pim-community-dev this vcs is useless