### PR TITLE
Doc: Fix path and download link in UPGRADE-1.5.md

### DIFF
--- a/UPGRADE-1.5.md
+++ b/UPGRADE-1.5.md
@@ -72,7 +72,6 @@ Copy the following files to your PIM installation:
 ```
  export PIM_DIR=/path/to/your/pim/installation
  cp app/SymfonyRequirements.php $PIM_DIR/app
- cp app/config/config.yml $PIM_DIR/app/config/
  cp composer.json $PIM_DIR/
 ```
 

--- a/UPGRADE-1.5.md
+++ b/UPGRADE-1.5.md
@@ -37,7 +37,7 @@ We've also removed the following requirements from composer.json, you can do the
 
 As usual, we provide upgrade commands to easily update projects migrating from 1.4 to 1.5.
 
-The app/config.yml mapping overrides has change:
+The `app/config/config.yml` mapping overrides has change:
 
 v1.4
 ```
@@ -62,7 +62,7 @@ akeneo_storage_utils:
 Download the latest [PIM community standard](http://www.akeneo.com/download/) and extract it:
 
 ```
- wget http://www.akeneo.com/pim-community-standard-v1.5-latest.tar.gz
+ wget http://download.akeneo.com/pim-community-standard-v1.5-latest.tar.gz
  tar -zxf pim-community-standard-v1.5-latest.tar.gz
  cd pim-community-standard-v1.5.*/
 ```


### PR DESCRIPTION
A side note: When reading the Upgrade document in the `pim-community-standard` repository, the first section "Catalog Bundle & Component" may be misleading: It talks about the files in `pim-community-dev` like f.ex. the `config.yml` which have a different content than described in the `pim-community-standard` repository.