### PR TITLE
[DO NOT MERGE] PIM-5788: Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,7 @@
         }
     },
     "require": {
-        "akeneo/pim-community-dev": "v1.6.0-ALPHA1",
-        "symfony/intl": "3.1.2",
-        "sensio/generator-bundle": "2.3.5"
-    },
-    "require-dev": {
-        "doctrine/migrations": "1.2.2",
-        "doctrine/doctrine-migrations-bundle": "1.1.0"
+        "akeneo/pim-community-dev": "v1.6.0-ALPHA2"
     },
     "repositories": [
         {


### PR DESCRIPTION
We have to tag the v1.6.0-ALPHA2 because of https://github.com/akeneo/pim-community-dev/pull/4814