### PR TITLE
[1.4] Update notifications from 1.3 with the correct context

### DIFF
--- a/upgrades/schema/Version_1_4_20170103083000_notification_context.php
+++ b/upgrades/schema/Version_1_4_20170103083000_notification_context.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Class Version_1_4_20170103083000_notification_context
+ *
+ * @author    Patrik Karisch <p.karisch@pixelart.at>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class Version_1_4_20170103083000_notification_context extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $contextMapping = [
+            'pim_import_export.notification.export' => ['actionType' => 'export'],
+            'pim_import_export.notification.import' => ['actionType' => 'import'],
+            'pim_mass_edit.notification.mass_edit' => ['actionType' => 'mass_edit'],
+            'pim_mass_edit.notification.quick_export' => ['actionType' => 'quick_export'],
+        ];
+
+        foreach ($contextMapping as $messagePart => $context) {
+            $context = serialize($context);
+
+            $this->addSql(<<<SQL
+                UPDATE pim_notification_notification
+                SET context = '{$context}'
+                WHERE message LIKE '{$messagePart}%'
+SQL
+            );
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | OSL 3.0

#### What's in this PR?

It updates all notifications with the correct context, which is normally set by the `JobExecutionNotifier`. This migration doesn't delete any notifications, the mapping from the message to the correct context is relative simple.

#### Why?

Without the correct context (empty context) the `NotificationController` fails in the template, because it's accessing the `actionType` without checking the existence of it.

#### Considerations

For people who are still upgrading existing 1.3 installations (like me :grin:) having this migration in the download is important.

I don't think there is a big need to distribute this migration to existing 1.4 installs. Either they don't have the error (started with 1.4) or already fixed this error on their own (e.g. emptied the notification table).