### PR TITLE
En route to Akeneo 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::removeSymfonyStandardFiles",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget",
-            "php app/console fos:js-routing:dump --target=web/js/routes.js"
+            "@php app/console fos:js-routing:dump --target=web/js/routes.js"
         ],
         "post-update-cmd": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
@@ -51,7 +51,7 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::removeSymfonyStandardFiles",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget",
-            "php app/console fos:js-routing:dump --target=web/js/routes.js",
+            "@php app/console fos:js-routing:dump --target=web/js/routes.js",
             "Pim\\Bundle\\InstallerBundle\\ComposerScripts::copyUpgradesFiles"
         ]
     },


### PR DESCRIPTION
My PHP 7.1 executable is named `php7.1`, not `php`, which is my 7.0 version.

Use instead `@php` in the composer.json scripts to use the same executable as the one is currently running