### PR TITLE
Extract dependencies install into a new Docker script helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,9 @@ vendor
 /bin/*
 !/bin/docker
 /bin/docker/*
-!/bin/docker/pim-initialize.sh
+!/bin/docker/pim-dependencies.sh
 !/bin/docker/pim-front.sh
+!/bin/docker/pim-initialize.sh
 !/bin/console
 composer.phar
 composer.lock

--- a/bin/docker/pim-dependencies.sh
+++ b/bin/docker/pim-dependencies.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+docker-compose exec fpm composer update
+docker-compose run --rm node npm install

--- a/bin/docker/pim-front.sh
+++ b/bin/docker/pim-front.sh
@@ -1,22 +1,7 @@
 #!/usr/bin/env bash
 
-currentDir=$(dirname "$0")
+docker-compose exec fpm bin/console --env=prod cache:clear --no-warmup
 
-echo "Clean previous assets"
+docker-compose exec fpm bin/console --env=prod pim:installer:assets --symlink --clean
 
-rm -rf ${currentDir}/../../var/cache/*
-rm -rf ${currentDir}/../../web/bundles/*
-rm -rf ${currentDir}/../../web/cache/*
-rm -rf ${currentDir}/../../web/css/*
-rm -rf ${currentDir}/../../web/dist/*
-rm -rf ${currentDir}/../../web/js/*
-
-echo "Install the assets"
-
-docker-compose exec fpm bin/console ca:c --env=prod
-
-docker-compose exec fpm bin/console --env=prod pim:installer:assets
-docker-compose exec fpm bin/console --env=prod assets:install --symlink
-
-docker-compose run node npm install
-docker-compose run node npm run webpack
+docker-compose run --rm node npm run webpack

--- a/bin/docker/pim-initialize.sh
+++ b/bin/docker/pim-initialize.sh
@@ -1,29 +1,7 @@
 #!/usr/bin/env bash
 
-currentDir=$(dirname "$0")
+docker-compose exec fpm bin/console --env=prod cache:clear --no-warmup
 
-echo "Clean previous install"
+docker-compose exec fpm bin/console --env=prod pim:install --force --symlink --clean
 
-rm -rf ${currentDir}/../../app/archive/*
-rm -rf ${currentDir}/../../var/cache/*
-rm -rf ${currentDir}/../../app/file_storage/*
-rm -rf ${currentDir}/../../var/logs/*
-rm -rf ${currentDir}/../../web/bundles/*
-rm -rf ${currentDir}/../../web/cache/*
-rm -rf ${currentDir}/../../web/css/*
-rm -rf ${currentDir}/../../web/dist/*
-rm -rf ${currentDir}/../../web/js/*
-rm -rf ${currentDir}/../../web/media/*
-
-echo "Install the PIM database"
-
-docker-compose exec fpm bin/console ca:c --env=prod
-
-docker-compose exec fpm bin/console --env=prod pim:install --force
-
-echo "Install the assets"
-
-docker-compose exec fpm bin/console --env=prod assets:install --symlink
-
-docker-compose run node npm install
-docker-compose run node npm run webpack
+docker-compose run --rm node npm run webpack

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -11,7 +11,7 @@ services:
     user: docker
     volumes:
       - ./:/srv/pim
-      - ~/.config/composer:/home/docker/.composer
+      - ~/.composer:/home/docker/.composer
     working_dir: /srv/pim
     networks:
       - akeneo
@@ -42,19 +42,19 @@ services:
   mysql:
     image: mysql:5.7
     environment:
-      - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_USER=akeneo_pim
-      - MYSQL_PASSWORD=akeneo_pim
-      - MYSQL_DATABASE=akeneo_pim
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_USER: akeneo_pim
+      MYSQL_PASSWORD: akeneo_pim
+      MYSQL_DATABASE: akeneo_pim
     ports:
       - '3306:3306'
     networks:
       - akeneo
 
   elasticsearch:
-    image: elasticsearch:5
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.5.2
     environment:
-      ES_JAVA_OPTS: '-Xms256m -Xmx256m'
+      ES_JAVA_OPTS: '-Xms512m -Xmx512m'
     ports:
       - '9200:9200'
     networks:


### PR DESCRIPTION
This PR bring to standard edition the last changes on Docker scripts from the `akeneo/pim-enterprise-dev`.

It removes the execution of `npm install` from the script `bin/docker/pim-initialize.sh`, and put it in a new script `bin/docker/pim-dependencies.sh` with `composer update`. This way, a developer can choose to install the PIM dependencies or not, before launching an install.

It also update the `docker-compose.yml.dist` file, using official Elasticsearch image instead of the one maintained by Docker.