### PR TITLE
Added missing mod_dir to httpd configuration for docker image

### DIFF
--- a/docker/httpd.conf
+++ b/docker/httpd.conf
@@ -24,6 +24,7 @@ LoadModule unixd_module modules/mod_unixd.so
 LoadModule status_module modules/mod_status.so
 LoadModule autoindex_module modules/mod_autoindex.so
 LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule dir_module modules/mod_dir.so
 
 <IfModule unixd_module>
     User daemon


### PR DESCRIPTION
The `DirectoryIndex app.php` in the `.htaccess` file requires the dir mod, without the mod you get an Error 500.

There is also an issue with the es docker, or a missing config on the fpm docker for the xpack installed by default that needs fixing.