### PR TITLE
Use Elasticsearch 5.6.1 with Docker Compose

### DIFF
--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -54,7 +54,7 @@ services:
       - akeneo
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.5.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.1
     environment:
       ES_JAVA_OPTS: '-Xms512m -Xmx512m'
     ports:


### PR DESCRIPTION
Update the file `docker-compose.yml.dist` to use the latest Elasticsearch version.