### PR TITLE
Fix production dependencies requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,6 @@
     "webpack-watch": "yarn run sync && NODE_PATH=node_modules webpack --progress --config $npm_package_config_source/webpack.config.js --watch"
   },
   "devDependencies": {
-    "colors": "1.1.2",
-    "dep-diff": "1.0.1",
     "read-pkg": "2.0.0"
   },
   "dependencies": {
@@ -29,7 +27,9 @@
     "backbone": "0.9.10",
     "bundle-loader": "0.5.5",
     "codemirror": "5.25.2",
+    "colors": "1.1.2",
     "deepmerge": "1.5.1",
+    "dep-diff": "1.0.1",
     "eslint": "4.5.0",
     "exports-loader": "0.6.4",
     "expose-loader": "0.7.3",


### PR DESCRIPTION
I've created this PR because i had problems running yarn run webpack after yarn install --production was executed. Now is able to run yarn run webpack in all environments "dev" & "prod" avoiding the dependencies requirements problems.