### PR TITLE
Update composer license name to fix packagist fetch issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "akeneo/pim-community-standard",
     "description": "The \"Akeneo Community Standard Edition\" distribution",
-    "license": "OSL 3.0",
+    "license": "OSL-3.0",
     "type": "project",
     "authors": [
         {


### PR DESCRIPTION
Packagist fails to fetch the 1.6 branch and tags due to a misconfiguration of the composer.json file license name:

```
Reading composer.json of akeneo/pim-community-standard (1.6) Importing branch 1.6 (1.6.x-dev) 
Skipped branch 1.6, Invalid package information: License "OSL 3.0" is not a valid SPDX license 
identifier, see https://spdx.org/licenses/ if you use an open license. If the software is closed-source, 
you may use "proprietary" as license.
```