### PR TITLE
Add MPM module to Apache Docker configuration

### DIFF
--- a/docker/httpd.conf
+++ b/docker/httpd.conf
@@ -2,6 +2,7 @@ ServerRoot "/usr/local/apache2"
 
 Listen 80
 
+LoadModule mpm_event_module modules/mod_mpm_event.so
 LoadModule authn_file_module modules/mod_authn_file.so
 LoadModule authn_core_module modules/mod_authn_core.so
 LoadModule authz_host_module modules/mod_authz_host.so


### PR DESCRIPTION
This change is mandatory with recent version of the "httpd" image. Without it, it is not possible to run containers anymore.

https://github.com/docker-library/httpd/pull/87#commitcomment-27128090