### PR TITLE
Exclude ambiguous AppKernel & AppCache from classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,11 @@
         "psr-4": {
           "Pim\\Upgrade\\": "upgrades/"
         },
-        "classmap": [ "app/AppKernel.php", "app/AppCache.php" ]
+        "classmap": [ "app/AppKernel.php", "app/AppCache.php" ],
+        "exclude-from-classmap": [
+            "vendor/akeneo/pim-community-dev/app/AppKernel.php",
+            "vendor/akeneo/pim-community-dev/app/AppCache.php"
+        ]
     },
     "require": {
         "akeneo/pim-community-dev": "2.0.x-dev@dev"


### PR DESCRIPTION
When composer is generating the autoloader (i.e. during composer update) it raises a warning about the ambiguous `AppKernel.php` and `AppCache.php` because they are present in both, the `pim-community-standard` and the `pim-community-dev`.
Adding the regarding classes from `pim-community-dev` to composers `exclude-from-classmap` resolves these warnings.

If you're running the enterprise-edition you will still get these warnings for the versions contained in the enterprise bundle. I'm not sure if the regarding classes should be added to the exclude in the standard-edition, too.