### PR TITLE
Small Docker Compose enhancements

### DIFF
--- a/bin/docker/pim-front.sh
+++ b/bin/docker/pim-front.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-docker-compose exec akeneo app/console --env=prod cache:clear --no-warmup
+docker-compose exec akeneo rm -rf app/cache/*
 
 docker-compose exec akeneo app/console --env=prod pim:installer:assets --symlink --clean

--- a/bin/docker/pim-initialize.sh
+++ b/bin/docker/pim-initialize.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-docker-compose exec akeneo app/console --env=prod cache:clear --no-warmup
+docker-compose exec akeneo rm -rf app/cache/*
 
 docker-compose exec akeneo app/console --env=prod pim:install --force --symlink --clean

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -7,8 +7,7 @@ services:
       COMPOSER_HOME: '/home/docker/.composer'
       PHP_IDE_CONFIG: 'serverName=pim-ce'
       PHP_XDEBUG_ENABLED: 0
-      PHP_XDEBUG_IDE_KEY: XDEBUG_IDE_KEY
-      PHP_XDEBUG_REMOTE_HOST: xxx.xxx.xxx.xxx
+      PHP_XDEBUG_IDE_KEY: 'XDEBUG_IDE_KEY'
       XDEBUG_CONFIG: 'remote_host=xxx.xxx.xxx.xxx'
     ports:
       - '8080:80'
@@ -29,14 +28,14 @@ services:
       MYSQL_PASSWORD: akeneo_pim
       MYSQL_DATABASE: akeneo_pim
     ports:
-      - '3306:3306'
+      - '33006:3306'
     networks:
       - akeneo
 
   mongodb:
     image: mongo:2.4
     ports:
-      - '21017:21017'
+      - '27117:27017'
     networks:
       - akeneo
 


### PR DESCRIPTION
This PR adds small improvements to the Docker Compose file and helper scripts:
- use `rm` command to delete cache, but only in containers (so it prevent deleting anything on the user machine outside of the PIM project)
- fix some minor default in YAML syntax
- remove `PHP_XDEBUG_REMOTE_HOST` as it is not needed most of the time (and is documented anyway)
- put more folder/files in read-only
- change the mapping of the port to avoid using already used ports on the host machine