### PR TITLE
Add a pim_dev_src_folder_location to avoid to change the std parameter file each time we release

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -58,3 +58,6 @@ swiftmailer:
     spool:                    { type: memory }
 
 pim_reference_data: ~
+
+parameters:
+    pim_ce_dev_src_folder_location: '%kernel.project_dir%/vendor/akeneo/pim-community-dev'

--- a/app/config/pim_parameters.yml
+++ b/app/config/pim_parameters.yml
@@ -53,4 +53,4 @@ parameters:
 
     # Files used as configuration for the Elasticsearch index
     elasticsearch_index_configuration_files:
-        - '%kernel.root_dir%/../vendor/akeneo/pim-community-dev/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml'
+        - '%pim_ce_dev_src_folder_location%/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml'


### PR DESCRIPTION
Backport of a commit by @juliensnz for the 2.0 to avoid issues during the tag process