### PR TITLE
PIM-7396: Load "pim.yml" before other parameters files

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -1,8 +1,8 @@
 imports:
+    - { resource: '@PimEnrichBundle/Resources/config/pim.yml' }
     - { resource: pim_parameters.yml }
     - { resource: parameters.yml }
     - { resource: security.yml }
-    - { resource: '@PimEnrichBundle/Resources/config/pim.yml' }
 
 framework:
     #esi:             ~


### PR DESCRIPTION
This allows for parameters defined in this file to be overridden in `app/config/parameters.yml`, like the parameter `pim_job_product_batch_size`.
