### PR TITLE
Use "akeneo/node" image in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,9 @@ services:
     volumes:
       - './:/srv/pim'
     working_dir: '/srv/pim'
+
   node:
-    image: 'juliensnz/node'
+    image: 'node:10-slim'
     user: 'node'
     volumes:
       - './:/srv/pim'


### PR DESCRIPTION
This PR update the `docker-compose.yml` file to use the `node:10-slim` image, to fit the Akeneo 3.0 requirements.