### PR TITLE
Remove composer aliases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,6 @@ workflows:
                   filters:
                       branches:
                           only:
-                              - master
+                              - "3.0"
         jobs:
             - build

--- a/composer.json
+++ b/composer.json
@@ -68,21 +68,6 @@
                 "database_password": "PIM_DATABASE_PASSWORD",
                 "index_hosts": "PIM_INDEX_HOSTS"
             }
-        },
-        "branch-alias": {
-            "dev-master": "3.0.x-dev",
-            "dev-2.3": "2.3.x-dev",
-            "dev-2.2": "2.2.x-dev",
-            "dev-2.1": "2.1.x-dev",
-            "dev-2.0": "2.0.x-dev",
-            "dev-1.7": "1.7.x-dev",
-            "dev-1.6": "1.6.x-dev",
-            "dev-1.5": "1.5.x-dev",
-            "dev-1.4": "1.4.x-dev",
-            "dev-1.3": "1.3.x-dev",
-            "dev-1.2": "1.2.x-dev",
-            "dev-1.1": "1.1.x-dev",
-            "dev-1.0": "1.0.x-dev"
         }
     }
 }


### PR DESCRIPTION
- master alias must be only on master branch
- we do not need other aliases on **comparable** versions