### PR TITLE
Fix git ignoring composer dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ vendor
 !/bin/docker/pim-setup.sh
 !/bin/console
 composer.phar
-composer.lock
 
 var/cache/*
 var/logs/*


### PR DESCRIPTION
This ensures best practice of commiting the composer.lock
file otherwise every installation of the project can result on
a different set of dependencies.

I'm not sure if the right branch is `master` but I can update the fix if any other branch is desired instead.