### PR TITLE
Fix install dependencies script for stop updating composer deps

### DIFF
--- a/bin/docker/pim-dependencies.sh
+++ b/bin/docker/pim-dependencies.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-docker-compose exec fpm php -d memory_limit=3G /usr/local/bin/composer update
+docker-compose exec fpm php -d memory_limit=3G /usr/local/bin/composer install
 
 docker-compose run --rm node yarn install


### PR DESCRIPTION
Using `update` instead `install` may produce an undesired Akeneo version to be installed when creating the project as follows e.g.

```
composer create-project --prefer-dist --no-install akeneo/pim-community-standard ./pim-ce-2.3.48 "2.3.48"
```
For later executing `bin/docker/install-dependencies.sh`
```
After all the Akeneo installed version is the latest one, currently `2.3.63` instead of `2.3.48` as indicated.