### PR TITLE
Accept only PHP 7.2 as Composer required version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         ]
     },
     "require": {
-        "php": ">=7.2.0",
+        "php": "7.2.*",
         "akeneo/pim-community-dev": "3.2.x-dev@dev"
     },
     "require-dev": {


### PR DESCRIPTION
This is already what `akeneo/pim-community-dev` accepts, so no BC-break.

Setting PHP to 7.2 and more can lead to confusion if people try to install it, assuming it can work with PHP 7.3 or 7.4, when it doesn't and is not even installable.

This already leads to a mistake on Bitnami setup: they seems to propose Akeneo 3.2 with PHP 7.3, and of course it doesn't work. A discussion was started about that [on SUG](https://akeneopim-ug.slack.com/archives/C0HLGPDL0/p1572233479124400).