### PR TITLE
Add CI step to run with dev dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
           command: sudo chown -R 1000:1000 ../project
       - run:
-          name: Install PHP dependencies
+          name: Install PHP dependencies - PIM tags
           command: docker run -u www-data -u www-data -v $(pwd):/srv/pim -w /srv/pim --rm akeneo/pim-php-dev:4.0 php -d memory_limit=4G /usr/local/bin/composer --prefer-dist install
       - run:
           name: Create mandatory yarn directories
@@ -33,6 +33,17 @@ jobs:
       - run:
           name: Test login page HTTP status
           command: curl -f http://localhost:8080/
+      - run:
+            name: Shutdown prod mode
+            command: make down
+      - run:
+            name: Install PHP dependencies - PIM dev
+            command: docker run -u www-data -u www-data -v $(pwd):/srv/pim -w /srv/pim --rm akeneo/pim-php-dev:4.0 php -d memory_limit=4G /usr/local/bin/composer require akeneo/pim-community-dev 4.0.x-dev
+      - run:
+            name: Launch the PIM in dev mode
+            command: make
+            environment:
+                YARN_REGISTRY: "http://registry.yarnpkg.com"
 
 workflows:
     version: 2

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,10 @@
         "akeneo/pim-community-dev": "^4.0.0"
     },
     "require-dev": {
-        "doctrine/doctrine-migrations-bundle": "1.3.2"
+        "doctrine/doctrine-migrations-bundle": "1.3.2",
+        "symfony/debug-bundle": "^4.4.7",
+        "symfony/web-profiler-bundle": "^4.4.7",
+        "symfony/web-server-bundle": "^4.4.7"
     },
     "scripts": {
         "post-update-cmd": [


### PR DESCRIPTION
This PR fixes dev dependencies for Standard Edition.

Also, it adds a CI step to test the installation with the last 4.0 dev branch.
The previous steps only tests installation with the last **stable** tag of pim-community-dev and don't detect errors on the current **dev** version.
Indeed, the standard edition was effectively broken since several days and was not detected by the CI until the yesterday tag, which is by the way also broken.

That's why we must alost test the installation with the last **@dev** version of pim-community-dev.