### PR TITLE
remove post-create-project-cmd

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,9 +35,6 @@
         ],
         "post-install-cmd": [
             "vendor/akeneo/pim-community-dev/std-build/install-required-files.sh"
-        ],
-        "post-create-project-cmd": [
-            "vendor/akeneo/pim-community-dev/std-build/install-required-files.sh"
         ]
     },
     "minimum-stability": "stable"


### PR DESCRIPTION
running vendor/akeneo/pim-community-dev/std-build/install-required-files.sh on post-create-project-cmd will break composer create-project --no-install. running scripts with create-project should only occur if they are already present with the composer.json files main project, without dependencies.