### PR TITLE
Test independently released CE version and development CE branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,9 @@ jobs:
                 name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
                 command: sudo chown -R 1000:1000 ../project
           - run:
+                name: Create mandatory yarn directories as explained in the documentation
+                command: mkdir -p ~/.cache/yarn && sudo chown -R 1000:1000 ~/.cache/yarn
+          - run:
                 name: Create the project as explained in the documentation
                 command: |
                     docker run -u www-data -v $(pwd):/srv/pim -w /srv/pim --rm akeneo/pim-php-dev:4.0 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,56 +1,80 @@
 version: 2
 jobs:
-  build:
-    machine:
-      image: ubuntu-1604:201903-01
-    steps:
-      - checkout
-      - run:
-          name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
-          command: sudo chown -R 1000:1000 ../project
-      - run:
-          name: Install PHP dependencies - PIM tags
-          command: docker run -u www-data -u www-data -v $(pwd):/srv/pim -w /srv/pim --rm akeneo/pim-php-dev:4.0 php -d memory_limit=4G /usr/local/bin/composer --prefer-dist install
-      - run:
-          name: Create mandatory yarn directories
-          command: mkdir -p ~/.cache/yarn && sudo chown -R 1000:1000 ~/.cache/yarn
-      - run:
-          name: Launch the PIM in dev mode
-          command: make
-          environment:
-              YARN_REGISTRY: "http://registry.yarnpkg.com"
-      - run:
-          name: Test login page HTTP status
-          command: curl -f http://localhost:8080/
-      - run:
-          name: Shutdown dev mode
-          command: make down
-      - run:
-          name: Launch the PIM in prod mode
-          command: make prod
-          environment:
-              YARN_REGISTRY: "http://registry.yarnpkg.com"
-      - run:
-          name: Test login page HTTP status
-          command: curl -f http://localhost:8080/
-      - run:
-            name: Shutdown prod mode
-            command: make down
-      - run:
-            name: Install PHP dependencies - PIM dev
-            command: docker run -u www-data -u www-data -v $(pwd):/srv/pim -w /srv/pim --rm akeneo/pim-php-dev:4.0 php -d memory_limit=4G /usr/local/bin/composer require akeneo/pim-community-dev 4.0.x-dev
-      - run:
-            name: Launch the PIM in dev mode
-            command: make
-            environment:
-                YARN_REGISTRY: "http://registry.yarnpkg.com"
+  build_last_release:
+      machine:
+          image: ubuntu-1604:201903-01
+      steps:
+          - run:
+                name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+                command: sudo chown -R 1000:1000 ../project
+          - run:
+                name: Create the project as explained in the documentation
+                command: |
+                    docker run -u www-data -v $(pwd):/srv/pim -w /srv/pim --rm akeneo/pim-php-dev:4.0 \
+                    php -d memory_limit=4G /usr/local/bin/composer create-project --prefer-dist \
+                    akeneo/pim-community-standard /srv/pim "4.0.*@stable"
+          - run:
+                name: Launch the PIM in dev mode
+                command: make
+                environment:
+                    YARN_REGISTRY: "http://registry.yarnpkg.com"
+          - run:
+                name: Test login page HTTP status
+                command: curl -f http://localhost:8080/
+          - run:
+                name: Shutdown dev mode
+                command: make down
+          - run:
+                name: Launch the PIM in prod mode
+                command: make prod
+                environment:
+                    YARN_REGISTRY: "http://registry.yarnpkg.com"
+          - run:
+                name: Test login page HTTP status
+                command: curl -f http://localhost:8080/
+
+  build_4_0_dev:
+      machine:
+          image: ubuntu-1604:201903-01
+      steps:
+          - checkout
+          - run:
+                name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+                command: sudo chown -R 1000:1000 ../project
+          - run:
+                name: Install PHP dependencies - Require the development branch 4.0
+                command: docker run -u www-data -u www-data -v $(pwd):/srv/pim -w /srv/pim --rm akeneo/pim-php-dev:4.0 php -d memory_limit=4G /usr/local/bin/composer require akeneo/pim-community-dev 4.0.x-dev
+          - run:
+                name: Create mandatory yarn directories
+                command: mkdir -p ~/.cache/yarn && sudo chown -R 1000:1000 ~/.cache/yarn
+          - run:
+                name: Launch the PIM in dev mode
+                command: make
+                environment:
+                    YARN_REGISTRY: "http://registry.yarnpkg.com"
+          - run:
+                name: Test login page HTTP status
+                command: curl -f http://localhost:8080/
+          - run:
+                name: Shutdown dev mode
+                command: make down
+          - run:
+                name: Launch the PIM in prod mode
+                command: make prod
+                environment:
+                    YARN_REGISTRY: "http://registry.yarnpkg.com"
+          - run:
+                name: Test login page HTTP status
+                command: curl -f http://localhost:8080/
+
 
 workflows:
     version: 2
 
     pull_request:
         jobs:
-            - build
+            - build_4_0_dev
+            - build_last_release
 
     nightly:
         triggers:
@@ -61,4 +85,5 @@ workflows:
                     only:
                       - "4.0"
         jobs:
-          - build
+          - build_last_release
+          - build_4_0_dev

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ If you want to contribute to the Akeneo PIM (and we will be pleased if you do!),
 Installation instructions
 -------------------------
 
-### Development Installation with Docker
+## Development Installation with Docker
 
-## Requirements
+It installs everything you need to run the PIM: source code, database, etc. This is the easiest way to have a PIM working in development mode. This is not a production setup.
+
+### Requirements
  - Docker 19+
  - docker-compose >= 1.24
  - make
@@ -21,28 +23,27 @@ Installation instructions
 The following steps will install Akeneo PIM in the current directory (must be empty) and launch it from there:
 
 ```bash
+$ mkdir -p ~/.cache/yarn
 $ docker run -u www-data -v $(pwd):/srv/pim -w /srv/pim --rm akeneo/pim-php-dev:4.0 \
     php -d memory_limit=4G /usr/local/bin/composer create-project --prefer-dist \
     akeneo/pim-community-standard /srv/pim "4.0.*@stable"
-```
-```
 $ make
-
 ```
 
 The PIM will be available on http://localhost:8080/, with `admin/admin` as default credentials.
 
-To shutdown your PIM: `make down`
+To shut down your PIM: `make down`
 
 ### Installation without Docker
 
+Without Docker, only the source code is installed. You have to install Mysql, Elasticsearch, etc.
 
 ```bash
 $ php -d memory_limit=4G /usr/local/bin/composer create-project --prefer-dist \
     akeneo/pim-community-standard /srv/pim "4.0.*@stable"
 ```
 
-You will need to change the `.env` file to configure the access to your MySQL and ES server.
+You will need to change the `.env` file to configure the access to your MySQL and Elasticsearch server.
 
 Once done, you can run:
 


### PR DESCRIPTION
The previous config was testing:
- the last tag of CE branch 4.0.x
- and then the dev branch 4.0

As everything was in the same jobs, there were some bugs.

For example, yarn was not re-installed when modifying composer to load the development CE branch. 
If a new dependency was added in the dev CE branch, it was failing due to this installation bug of the CI. 

Splitting it in two jobs allows us to:
- test the release version exactly the same way as we document how to create a new project in the documentation
- test the CE branch without relying of previously installed stuff, which can be incomplete/not up to date