### PR TITLE
Fix the make target used for building the front

### DIFF
--- a/.circleci/test_migrations_from_4_0.sh
+++ b/.circleci/test_migrations_from_4_0.sh
@@ -43,7 +43,7 @@ install_pim_without_database() {
   APP_ENV=dev make up
   # Wait for docker up. This is not mandatory but it checks the containers are working properly.
   ./docker/wait_docker_up.sh
-  APP_ENV=dev PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 make node_modules cache assets javascript-dev
+  APP_ENV=dev PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 make node_modules cache front
 }
 
 copy_migrations_to_upgrades_directory() {


### PR DESCRIPTION
When building the front part of the PIM, instead of relying on independant make steps,
it's better to directly call the `make front` : https://github.com/akeneo/pim-community-dev/blob/07faafa9934bdc43c29f0cf49a9e983a772c03ae/std-build/Makefile#L49

The latest changes isolated the `dsm` & `css` from the `javascript-dev`