### PR TITLE
RAB-1127: Use PHP 8.1 in order to launch composer install on standard edition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: sudo chown -R 1000:1000 ../project
       - run:
           name: Install PHP dependencies
-          command: docker run -u www-data -u www-data -v $(pwd):/srv/pim -w /srv/pim --rm akeneo/pim-php-dev:8.1 composer --prefer-dist install
+          command: docker run -u www-data -v $(pwd):/srv/pim -w /srv/pim --rm akeneo/pim-php-dev:8.1 composer --prefer-dist install
       - run:
           name: Create mandatory yarn directories
           command: mkdir -p ~/.cache/yarn ~/.cache/Cypress ~/.composer && sudo chown -R 1000:1000 ~/.cache/yarn ~/.cache/Cypress ~/.composer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2204:2022.07.1
     steps:
       - checkout
       - run:
@@ -10,7 +10,7 @@ jobs:
           command: sudo chown -R 1000:1000 ../project
       - run:
           name: Install PHP dependencies
-          command: docker run -u www-data -u www-data -v $(pwd):/srv/pim -w /srv/pim --rm akeneo/pim-php-dev:6.0 php -d memory_limit=4G /usr/local/bin/composer --prefer-dist install
+          command: docker run -u www-data -u www-data -v $(pwd):/srv/pim -w /srv/pim --rm akeneo/pim-php-dev:8.1 composer --prefer-dist install
       - run:
           name: Create mandatory yarn directories
           command: mkdir -p ~/.cache/yarn ~/.cache/Cypress ~/.composer && sudo chown -R 1000:1000 ~/.cache/yarn ~/.cache/Cypress ~/.composer
@@ -36,7 +36,7 @@ jobs:
 
   test_migrations_from_6_0:
       machine:
-          image: ubuntu-2004:202101-01
+          image: ubuntu-2204:2022.07.1
       steps:
           - checkout
           - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,10 +40,6 @@ jobs:
       steps:
           - checkout
           - run:
-                name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
-                command: |
-                    sudo chown -R 1000:1000 ../project
-          - run:
                 name: Create mandatory composer and yarn directories
                 command: |
                     mkdir -p ~/.composer ~/.cache/yarn ~/.cache/Cypress

--- a/.circleci/test_migrations_from_6_0.sh
+++ b/.circleci/test_migrations_from_6_0.sh
@@ -107,7 +107,7 @@ docker run --user www-data --rm \
   --volume $(pwd):/srv/pim --volume ~/.composer:/var/www.composer --volume ~/.ssh:/var/www/.ssh \
   --workdir /srv/pim \
   --env COMPOSER_AUTH \
-  akeneo/pim-php-dev:master \
+  akeneo/pim-php-dev:8.1 \
   composer install --no-interaction
 
 sudo rm -rf ${PROJECT_DIR}/var/cache/*


### PR DESCRIPTION
In this PR, I changed : 
- The PHP version used by pim-community-standard to 8.1 => as now the PIM need PHP 8.1
- I updated the image used by CircleCi => It the same image than the EE CircleCi

Related change: 
- https://github.com/akeneo/pim-enterprise-dev/pull/15343
- https://github.com/akeneo/pim-community-dev/pull/18252
- https://github.com/akeneo/pim-onboarder/pull/1038