### PR TITLE
Fix elasticsearch need to be migrated to 7.17.7 before upgrading to 8.5

### DIFF
--- a/.circleci/test_migrations_from_6_0.sh
+++ b/.circleci/test_migrations_from_6_0.sh
@@ -22,6 +22,12 @@ usage() {
 }
 
 update_docker_compose_config_to_use_volumes() {
+  OVERRIDDEN_ELASTICSEARCH_VERSION=''
+  if [ "$#" -gt 0 ] && [ ! -z "$1" ]
+  then
+    OVERRIDDEN_ELASTICSEARCH_VERSION="image: 'elastic/elasticsearch:${1}'"
+  fi
+
   [ ! -d "${MYSQL_DATA_DIR}" ] && mkdir -p "${MYSQL_DATA_DIR}" && sudo chown -R 1000:1000 "${MYSQL_DATA_DIR}"
   [ ! -d "${ELASTICSEARCH_DATA_DIR}" ] && mkdir -p "${ELASTICSEARCH_DATA_DIR}" && sudo chown -R 1000:1000 "${ELASTICSEARCH_DATA_DIR}"
   echo "
@@ -32,6 +38,7 @@ services:
         volumes:
             - '${MYSQL_DATA_DIR}:/var/lib/mysql'
     elasticsearch:
+        ${OVERRIDDEN_ELASTICSEARCH_VERSION}
         volumes:
             - '${ELASTICSEARCH_DATA_DIR}:/usr/share/elasticsearch/data'
 " > docker-compose.override.yml
@@ -111,6 +118,13 @@ docker run --user www-data --rm \
   composer install --no-interaction
 
 sudo rm -rf ${PROJECT_DIR}/var/cache/*
+
+echo "Launch PIM with elasticsearch 7.17.7 as elasticsearch need to be started with 7.17.7 before upgrading to 8.5"
+update_docker_compose_config_to_use_volumes 7.17.7
+source .env
+APP_ENV=dev make up
+./docker/wait_docker_up.sh
+APP_ENV=dev make down
 
 echo "Update docker-compose configuration to use volumes for MySQL and Elasticsearch containers..."
 update_docker_compose_config_to_use_volumes


### PR DESCRIPTION
In this PR, I fixed the standard nightly => the CI does not pass anymore because during the migration we pass from 7.6.2 to 8.5. This is not allowed by Elasticsearch we should use the 7.17.7 before migration to 8.5.